### PR TITLE
Enable multi batiment detail windows

### DIFF
--- a/cadastrapp/js/habitationDetails.js
+++ b/cadastrapp/js/habitationDetails.js
@@ -14,7 +14,6 @@ GEOR.Addons.Cadastre.showHabitationDetails = function(batiment, niveau, porte, a
     
     // Creation de la fenetre de details d'habitation
     var habitationDetailsWindows = new Ext.Window({
-        id:"cadHabDetailsWindows",
         title:" Batiment " + batiment + " - niveau "+ niveau+ " - porte " + porte,
         frame : true,
         autoScroll : true,


### PR DESCRIPTION
Correct the bug in this Issue : https://github.com/GFI-Informatique/cadastrapp/issues/150

By enabling multiple batiment detail windows to be opened at same time. (No window id)
